### PR TITLE
fix: 403 get response error

### DIFF
--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/http/TikTokHttpRequestFactory.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/http/TikTokHttpRequestFactory.java
@@ -38,6 +38,14 @@ public class TikTokHttpRequestFactory implements TikTokHttpRequest {
     public String get(String url) {
         var uri = URI.create(url);
         var request = HttpRequest.newBuilder().GET();
+        for (var header : defaultHeaders.entrySet())
+        {
+            if(header.getKey().equals("Connection") || header.getKey().equals("Accept-Encoding"))
+            {
+                continue;
+            }
+            request.setHeader(header.getKey(), header.getValue());
+        }
         if (query != null) {
             var baseUri = uri.toString();
             var requestUri = URI.create(baseUri + "?" + query);


### PR DESCRIPTION
When I use this project then I see this exception:

```
io.github.jwdeveloper.tiktok.exceptions.TikTokLiveRequestException: Failed to fetch room id from WebCast, see stacktrace for more info.
```

This pull request solve this issue. I removed "Accept-Encoding" header because it will get json parse issue. 