### PR TITLE
Fix for mapping of HttpResponse & HttpRequest and more!

### DIFF
--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/common/ActionResult.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/common/ActionResult.java
@@ -1,14 +1,21 @@
 package io.github.jwdeveloper.tiktok.common;
 
 import com.google.gson.*;
+import io.github.jwdeveloper.tiktok.http.mappers.*;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
+import java.net.http.*;
 import java.util.Optional;
 import java.util.function.Function;
 
 @Data
 public class ActionResult<T> {
+
+	private static final Gson gson = new Gson().newBuilder().disableHtmlEscaping()
+		.registerTypeHierarchyAdapter(HttpResponse.class, new HttpResponseJsonMapper())
+		.registerTypeHierarchyAdapter(HttpRequest.class, new HttpRequestJsonMapper())
+		.setPrettyPrinting().create();
 
 	private boolean success = true;
 	private T content;
@@ -93,7 +100,7 @@ public class ActionResult<T> {
 	public JsonObject toJson() {
 		JsonObject map = new JsonObject();
 		map.addProperty("success", success);
-		map.add("content", new Gson().toJsonTree(content));
+		map.add("content", gson.toJsonTree(content));
 		map.addProperty("message", message);
 		map.add("previous", hasPrevious() ? previous.toJson() : null);
 		return map;
@@ -101,6 +108,6 @@ public class ActionResult<T> {
 
 	@Override
 	public String toString() {
-		return "ActionResult: "+new Gson().newBuilder().setPrettyPrinting().create().toJson(toJson());
+		return "ActionResult: "+gson.toJson(toJson());
 	}
 }

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/HttpRequestJsonMapper.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/HttpRequestJsonMapper.java
@@ -1,0 +1,21 @@
+package io.github.jwdeveloper.tiktok.http.mappers;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.net.http.HttpRequest;
+
+public class HttpRequestJsonMapper implements JsonSerializer<HttpRequest>
+{
+	@Override
+	public JsonElement serialize(HttpRequest src, Type typeOfSrc, JsonSerializationContext context) {
+		JsonObject object = new JsonObject();
+		object.addProperty("method", src.method());
+		object.add("timeout", context.serialize(src.timeout().toString()));
+		object.addProperty("expectContinue", src.expectContinue());
+		object.add("uri", context.serialize(src.uri()));
+		object.add("version", context.serialize(src.version().toString()));
+		object.add("headers", context.serialize(src.headers().map()));
+		return object;
+	}
+}

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/HttpResponseJsonMapper.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/HttpResponseJsonMapper.java
@@ -1,0 +1,21 @@
+package io.github.jwdeveloper.tiktok.http.mappers;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.net.http.HttpResponse;
+
+public class HttpResponseJsonMapper implements JsonSerializer<HttpResponse>
+{
+	@Override
+	public JsonElement serialize(HttpResponse src, Type typeOfSrc, JsonSerializationContext context) {
+		JsonObject object = new JsonObject();
+		object.addProperty("statusCode", src.statusCode());
+		object.add("request", context.serialize(src.request()));
+		object.add("headers", context.serialize(src.headers().map()));
+		object.add("body", context.serialize(src.body()));
+		object.add("uri", context.serialize(src.uri().toString()));
+		object.add("version", context.serialize(src.version().toString()));
+		return object;
+	}
+}

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/LiveUserDataMapper.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/http/mappers/LiveUserDataMapper.java
@@ -65,7 +65,7 @@ public class LiveUserDataMapper
             };
 
             return new LiveUserData.Response(json, statusEnum, roomId, startTime);
-        } catch (JsonSyntaxException e) {
+        } catch (JsonSyntaxException | IllegalStateException e) {
             logger.warning("Malformed Json: '"+json+"' - Error Message: "+e.getMessage());
             return new LiveUserData.Response(json, LiveUserData.UserStatus.NotFound, "", -1);
         }


### PR DESCRIPTION
Added IllegalStateException to LiveUserDataMapper to catch `getAsJsonObject` exception.

Created HttpRequestJsonMapper and HttpResponseJsonMapper for ActionResult gson parser.