### PR TITLE
Downgrade protobuf-java version from 4.28.3 to 4.26.1 in pom.xml files.

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.28.3</version>
+            <version>4.26.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -51,7 +51,7 @@
                         </goals>
                         <configuration>
                             <includeMavenTypes>direct</includeMavenTypes>
-                            <protocVersion>4.28.3</protocVersion>
+                            <protocVersion>4.26.1</protocVersion>
                             <inputDirectories>
                                 <include>src/main/proto</include>
                             </inputDirectories>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.28.3</version>
+            <version>4.26.1</version>
         </dependency>
 
         <dependency>

--- a/extension-collector/pom.xml
+++ b/extension-collector/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.28.3</version>
+            <version>4.26.1</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>


### PR DESCRIPTION
An error occurred through my fault, there is a fix. runtime protobuf works on version 4.26.1

```ex
Caused by: com.google.protobuf.RuntimeVersion$ProtobufRuntimeVersionException: Detected incompatible Protobuf Gencode/Runtime versions when loading io.github.jwdeveloper.tiktok.messages.webcast.WebcastResponse: gencode 4.28.3, runtime 4.26.1. Runtime version cannot be older than the linked gencode version.
```