### PR TITLE
Fix: Add the missing API Key on send chat calls. #138

### DIFF
--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
@@ -204,6 +204,8 @@ public class TikTokLiveHttpClient implements LiveHttpClient
         body.addProperty("sessionId", clientSettings.getSessionId());
         body.addProperty("ttTargetIdc", clientSettings.getTtTargetIdc());
         body.addProperty("roomId", roomInfo.getRoomId());
+        if (clientSettings.getApiKey() != null)
+            body.addProperty("apiKey", clientSettings.getApiKey());
         var result = httpFactory.client(TIKTOK_CHAT_URL)
             .withHeader("Content-Type", "application/json")
             .withBody(HttpRequest.BodyPublishers.ofString(body.toString()))


### PR DESCRIPTION
Hey @kohlerpop1, 

I believe this might do the trick to fix the API call. I basically tried to replicate from the function `getByteResponse`. 

