### PR TITLE
Fix: API Key added in the body instead of param

### DIFF
--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
@@ -204,6 +204,8 @@ public class TikTokLiveHttpClient implements LiveHttpClient
         body.addProperty("sessionId", clientSettings.getSessionId());
         body.addProperty("ttTargetIdc", clientSettings.getTtTargetIdc());
         body.addProperty("roomId", roomInfo.getRoomId());
+        if (clientSettings.getApiKey() != null)
+            body.addProperty("apiKey", clientSettings.getApiKey());
         var result = httpFactory.client(TIKTOK_CHAT_URL)
             .withHeader("Content-Type", "application/json")
             .withBody(HttpRequest.BodyPublishers.ofString(body.toString()))

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
@@ -204,12 +204,11 @@ public class TikTokLiveHttpClient implements LiveHttpClient
         body.addProperty("sessionId", clientSettings.getSessionId());
         body.addProperty("ttTargetIdc", clientSettings.getTtTargetIdc());
         body.addProperty("roomId", roomInfo.getRoomId());
-        var result = httpFactory.client(TIKTOK_CHAT_URL)
-            .withHeader("Content-Type", "application/json")
-            .withHeader("apiKey", clientSettings.getApiKey())
-            .withBody(HttpRequest.BodyPublishers.ofString(body.toString()))
-            .build()
-            .toJsonResponse();
+        HttpClientBuilder builder = httpFactory.client(TIKTOK_CHAT_URL)
+            .withHeader("Content-Type", "application/json");
+        if (clientSettings.getApiKey() != null)
+            builder.withHeader("apiKey", clientSettings.getApiKey());
+        var result = builder.withBody(HttpRequest.BodyPublishers.ofString(body.toString())).build().toJsonResponse();
         return result.isSuccess();
     }
 

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
@@ -204,12 +204,12 @@ public class TikTokLiveHttpClient implements LiveHttpClient
         body.addProperty("sessionId", clientSettings.getSessionId());
         body.addProperty("ttTargetIdc", clientSettings.getTtTargetIdc());
         body.addProperty("roomId", roomInfo.getRoomId());
-        HttpClientBuilder request = httpFactory.client(TIKTOK_CHAT_URL)
-                .withHeader("Content-Type", "application/json")
-                .withBody(HttpRequest.BodyPublishers.ofString(body.toString()));
-        if (clientSettings.getApiKey() != null)
-            request.withParam("apiKey", clientSettings.getApiKey());
-        var result = request.build().toJsonResponse();
+        var result = httpFactory.client(TIKTOK_CHAT_URL)
+            .withHeader("Content-Type", "application/json")
+            .withHeader("apiKey", clientSettings.getApiKey())
+            .withBody(HttpRequest.BodyPublishers.ofString(body.toString()))
+            .build()
+            .toJsonResponse();
         return result.isSuccess();
     }
 

--- a/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
+++ b/Client/src/main/java/io/github/jwdeveloper/tiktok/TikTokLiveHttpClient.java
@@ -204,13 +204,12 @@ public class TikTokLiveHttpClient implements LiveHttpClient
         body.addProperty("sessionId", clientSettings.getSessionId());
         body.addProperty("ttTargetIdc", clientSettings.getTtTargetIdc());
         body.addProperty("roomId", roomInfo.getRoomId());
+        HttpClientBuilder request = httpFactory.client(TIKTOK_CHAT_URL)
+                .withHeader("Content-Type", "application/json")
+                .withBody(HttpRequest.BodyPublishers.ofString(body.toString()));
         if (clientSettings.getApiKey() != null)
-            body.addProperty("apiKey", clientSettings.getApiKey());
-        var result = httpFactory.client(TIKTOK_CHAT_URL)
-            .withHeader("Content-Type", "application/json")
-            .withBody(HttpRequest.BodyPublishers.ofString(body.toString()))
-            .build()
-            .toJsonResponse();
+            request.withParam("apiKey", clientSettings.getApiKey());
+        var result = request.build().toJsonResponse();
         return result.isSuccess();
     }
 


### PR DESCRIPTION
Yesterday’s PR was flawed, my mistake. While testing the integration this morning, I realised I had added the apiKey in the body instead of as a request parameter. This update should fix the issue.

PS: I’ve been trying to package it locally to test directly with my code, but after an hour I keep running into issues with the licence plugin failing to execute. Any chance you could run it quickly on your side, or share the instructions to get it working? Sorry about that, it feels a bit amateurish, but I need to move on to other tasks today. I’m fairly confident the mistake from last time is fixed after re-reading the documentation, but I would have preferred to test it properly.