### PR TITLE
Bump the maven group across 4 directories with 4 updates

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.26.1</version>
+            <version>4.27.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/Client/pom.xml
+++ b/Client/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.26.1</version>
+            <version>4.27.5</version>
         </dependency>
 
         <dependency>
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.4.0</version> <!-- Use the desired TestNG version -->
+            <version>7.5.1</version> <!-- Use the desired TestNG version -->
             <scope>test</scope>
         </dependency>
 

--- a/extension-collector/pom.xml
+++ b/extension-collector/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>4.26.1</version>
+            <version>4.27.5</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/tools-readme/pom.xml
+++ b/tools-readme/pom.xml
@@ -26,12 +26,12 @@
         <dependency>
             <groupId>com.hubspot.jinjava</groupId>
             <artifactId>jinjava</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.6</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.13.0</version>
+            <version>2.14.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps the maven group with 2 updates in the /tools-readme directory: [com.hubspot.jinjava:jinjava](https://github.com/HubSpot/jinjava) and commons-io:commons-io.
Bumps the maven group with 1 update in the /extension-collector directory: [com.google.protobuf:protobuf-java](https://github.com/protocolbuffers/protobuf).
Bumps the maven group with 2 updates in the /Client directory: [com.google.protobuf:protobuf-java](https://github.com/protocolbuffers/protobuf) and [org.testng:testng](https://github.com/cbeust/testng).
Bumps the maven group with 1 update in the /API directory: [com.google.protobuf:protobuf-java](https://github.com/protocolbuffers/protobuf).


Updates `com.hubspot.jinjava:jinjava` from 2.7.2 to 2.7.6
- [Release notes](https://github.com/HubSpot/jinjava/releases)
- [Changelog](https://github.com/HubSpot/jinjava/blob/master/CHANGES.md)
- [Commits](https://github.com/HubSpot/jinjava/compare/jinjava-2.7.2...jinjava-2.7.6)

Updates `commons-io:commons-io` from 2.13.0 to 2.14.0

Updates `com.google.protobuf:protobuf-java` from 4.26.1 to 4.27.5
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Commits](https://github.com/protocolbuffers/protobuf/commits)

Updates `com.google.protobuf:protobuf-java` from 4.26.1 to 4.27.5
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Commits](https://github.com/protocolbuffers/protobuf/commits)

Updates `org.testng:testng` from 7.4.0 to 7.5.1
- [Release notes](https://github.com/cbeust/testng/releases)
- [Changelog](https://github.com/testng-team/testng/blob/master/CHANGES.txt)
- [Commits](https://github.com/cbeust/testng/compare/7.4.0...7.5.1)

Updates `com.google.protobuf:protobuf-java` from 4.26.1 to 4.27.5
- [Release notes](https://github.com/protocolbuffers/protobuf/releases)
- [Commits](https://github.com/protocolbuffers/protobuf/commits)

---
updated-dependencies:
- dependency-name: com.hubspot.jinjava:jinjava dependency-version: 2.7.6 dependency-type: direct:production dependency-group: maven
- dependency-name: commons-io:commons-io dependency-version: 2.14.0 dependency-type: direct:production dependency-group: maven
- dependency-name: com.google.protobuf:protobuf-java dependency-version: 4.27.5 dependency-type: direct:production dependency-group: maven
- dependency-name: com.google.protobuf:protobuf-java dependency-version: 4.27.5 dependency-type: direct:production dependency-group: maven
- dependency-name: org.testng:testng dependency-version: 7.5.1 dependency-type: direct:development dependency-group: maven
- dependency-name: com.google.protobuf:protobuf-java dependency-version: 4.27.5 dependency-type: direct:production dependency-group: maven ...